### PR TITLE
fix: side effects to false in package.json

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,14 +33,6 @@ const nextConfig = {
       },
     ]
   },
-  webpack(config) {
-    config.module.rules.push({
-      test: [/src\/(components|libs|utils)\/index.ts/i],
-      sideEffects: false,
-    })
-
-    return config
-  },
 }
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "enaut.dev",
   "private": true,
+  "sideEffects": "false",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
After merged #1, a better solution was to set directly `sideEffects` to `false` in the `package.json` ([source](https://twitter.com/haroenv/status/1554131323887009792)).